### PR TITLE
The test scripts run in a temporary directory

### DIFF
--- a/test/gimic-test-2D.sh
+++ b/test/gimic-test-2D.sh
@@ -6,7 +6,10 @@ function runtest_2D() {
 	printf "\n\nPerforming test on $testname 2D current density\n\n"
     fi
 
-    (cd ./$testname/2D && $gimicdir/gimic gimic.inp > gimic.test.out )
+    mkdir ../tmp/$testname
+    cp ./$testname/MOL ./$testname/XDENS ../tmp
+    cp ./$testname/2D/gimic.inp ../tmp/$testname
+    (cd ../tmp/$testname && $gimicdir/gimic gimic.inp > gimic.test.out )
 
 
     # variable to track the number of the test executed
@@ -15,7 +18,7 @@ function runtest_2D() {
     for file in "jvec.txt" "jvec.vti" "acid.txt" "jmod.txt"
     do
 	i=$(( $i + 1 ))
-	if diff ./$testname/2D/$file ./$testname/2D/$file.ref >/dev/null
+	if diff ../tmp/$testname/$file ./$testname/2D/$file.ref >/dev/null
 	then
 #	    test$i=0
 	    if [ $verbose -eq 1 ]
@@ -39,7 +42,9 @@ function runtest_2D() {
 	echo $success # successful result is success=0
     fi
 
-}
+    rm -rf ../tmp/MOL rm -rf ../tmp/XDENS
+} # end function runtest_2D
+
 
 arg="$2"
 #echo Argument 2: $arg
@@ -69,6 +74,9 @@ fi
 # Initialize the variable to check the success of the test runs
 success=0
 
+# Make a temporary directory for the test
+mkdir ../tmp
+
 #molecules="benzene C4H4"
 molecules="benzene"
 
@@ -81,5 +89,7 @@ if [ $verbose -eq 1 ]
 then
     printf "\nSuccess of all tests:\n"
 fi
+
+rm -rf ../tmp
 
 echo $success

--- a/test/gimic-test-3D.sh
+++ b/test/gimic-test-3D.sh
@@ -6,7 +6,10 @@ function runtest_3D() {
 	printf "\n\nPerforming test on $testname 3D current density\n\n"
     fi
 
-    (cd ./$testname/3D && $gimicdir/gimic gimic.inp > gimic.test.out )
+    mkdir ../tmp/$testname
+    cp ./$testname/MOL ./$testname/XDENS ../tmp
+    cp ./$testname/3D/gimic.inp ../tmp/$testname
+    (cd ../tmp/$testname && $gimicdir/gimic gimic.inp > gimic.test.out )
 
 
     # variable to track the number of the test executed
@@ -15,7 +18,7 @@ function runtest_3D() {
     for file in "jvec.txt" "jvec.vti" "acid.cube" "acid.txt" "acid.vti" "jmod.cube" "jmod_quasi.cube" "jmod.vti" "jmod.txt"
     do
 	i=$(( $i + 1 ))
-	if diff ./$testname/3D/$file ./$testname/3D/$file.ref >/dev/null
+	if diff ../tmp/$testname/$file ./$testname/3D/$file.ref >/dev/null
 	then
 #	    test$i=0
 	    if [ $verbose -eq 1 ]
@@ -39,7 +42,9 @@ function runtest_3D() {
 	echo $success # successful result is success=0
     fi
 
-}
+    rm -rf ../tmp/MOL rm -rf ../tmp/XDENS
+
+} # end function runtest_3D
 
 arg="$2"
 #echo Argument 2: $arg
@@ -69,6 +74,9 @@ fi
 # Initialize the variable to check the success of the test runs
 success=0
 
+# Make a temporary directory for the test
+mkdir ../tmp
+
 #molecules="benzene C4H4"
 molecules="benzene"
 
@@ -81,5 +89,7 @@ if [ $verbose -eq 1 ]
 then
     printf "\nSuccess of all tests:\n"
 fi
+
+rm -rf ../tmp
 
 echo $success

--- a/test/gimic-test.sh
+++ b/test/gimic-test.sh
@@ -6,11 +6,16 @@ function runtest() {
 	printf "\n\nPerforming test on $testname bond integral\n\n"
     fi
 
-    (cd ./$testname/int && $gimicdir/gimic gimic.inp > gimic.test.out )
+    # Create a temporary directory for each test molecule, copy the input file there, then execute the calculation in it
+    mkdir ../tmp/$testname
 
-    diatropic=$(grep -A 2 "Induced current" ./$testname/int/gimic.test.out | awk '{ if (NR == 2) printf("% f\n", $5); }')
-    paratropic=$(grep -A 2 "Induced current" ./$testname/int/gimic.test.out | awk '{ if (NR == 3) printf("% f\n", $5); }')
-    total=$(grep "Induced current (nA/T)" ./$testname/int/gimic.test.out | awk '{printf("% f\n", $5); }')
+    cp ./$testname/int/gimic.inp ../tmp/$testname 
+    cp ./$testname/MOL ./$testname/XDENS ../tmp
+    (cd ../tmp/$testname  && $gimicdir/gimic gimic.inp > gimic.test.out )
+
+    diatropic=$(grep -A 2 "Induced current" ../tmp/$testname/gimic.test.out | awk '{ if (NR == 2) printf("% f\n", $5); }')
+    paratropic=$(grep -A 2 "Induced current" ../tmp/$testname/gimic.test.out | awk '{ if (NR == 3) printf("% f\n", $5); }')
+    total=$(grep "Induced current (nA/T)" ../tmp/$testname/gimic.test.out | awk '{printf("% f\n", $5); }')
 
     # Debugging
     if [ $verbose -eq 1 ]
@@ -53,7 +58,7 @@ function runtest() {
 	echo $success # successful result is success=0
     fi
 
-    rm -rf ./$testname/int/XDENS ./$testname/int/MOL
+    rm -rf ../tmp/XDENS ../tmp/MOL
 }
 
 arg="$2"
@@ -71,8 +76,6 @@ else
     verbose=0 # verbose off
 fi
 
-#echo Verbose? $verbose
-
 gimicdir="$1"
 
 if [ -z $gimicdir ]
@@ -83,6 +86,9 @@ fi
 
 # Initialize the variable to check the success of the test runs
 success=0
+
+# Make a temporary directory for the test
+mkdir ../tmp
 
 molecules="benzene C4H4"
 
@@ -95,5 +101,11 @@ if [ $verbose -eq 1 ]
 then
     printf "\nSuccess of all tests:\n"
 fi
+
+#    if [ $success -eq 0 ]
+#    then
+	rm -rf ../tmp
+ #   fi
+
 
 echo $success


### PR DESCRIPTION
The tmp directory is deleted after execution. If a test returns a non-zero value, then it can be executed manually with -v `./gimic-test.sh $GIMICDIR -v` and the user can see details on what exactly passes and fails. 

This was a very good suggestion to move the test calculations to a place that Git doesn't track. It makes my life easier that I don't need to set up a .gitignore file or manually remove the unneeded files from git status. 