### PR TITLE
Turbo2gimic prints an error message if there is a Q dummy atom without a basis

### DIFF
--- a/tools/turbo2gimic.py.in
+++ b/tools/turbo2gimic.py.in
@@ -28,6 +28,9 @@ def main():
     for i in range(1,len(atoms)):
         a=atoms[i]
         sym=string.upper(a.element.symbol)
+        if sym == 'Q':
+            sys.stderr.write("\n*** ERROR ***\nAtoms without basis functions should be removed from the control file \n\n")
+            sys.exit(1)
         b=basis[sym]
         print float(a.element.number),'  ', 1, b
         print "%2s%2i%20.12f%20.12f%20.12f" % \


### PR DESCRIPTION
Hello,

I added a small notification in case there is a dummy atom q with charge but no basis in the control file. If you approve of it, you can merge it. Without it the script stops with a somewhat unclear error:

```
Traceback (most recent call last):
  File "/homeappl/home/mariavd/appl_taito/gimic/install/bin/turbo2gimic.py", line 133, in <module>
    main()
  File "/homeappl/home/mariavd/appl_taito/gimic/install/bin/turbo2gimic.py", line 31, in main
    b=basis[sym]
KeyError: 'Q'
```