### PR TITLE
rm trailing whitespace to get more meaningful diffs when comparing branches

### DIFF
--- a/src/fgimic/grid.f90
+++ b/src/fgimic/grid.f90
@@ -97,7 +97,7 @@ contains
             if (keyword_is_set(input, 'Grid.rotation_origin')) then
                 call getkw(input, 'Grid.rotation_origin', ref)
             else
-                !            call getkw(input, 'Grid.out', out_length) 
+                !            call getkw(input, 'Grid.out', out_length)
                 !            call getkw(input, 'Grid.down', down_length)
                 if (keyword_is_set(input, 'Grid.height')) then
                     call getkw(input, 'Grid.height', hgt)
@@ -764,7 +764,7 @@ contains
 
         this%basv=matmul(euler,this%basv)
         this%origin=matmul(euler,this%origin)
- 
+
         this%origin=this%origin+reference
    end subroutine
 

--- a/src/gimic.in
+++ b/src/gimic.in
@@ -196,7 +196,7 @@ def check_grid(grid):
     elif arg == 'file':
         required=('file',)
         ignore=('ivec', 'jvec', 'bond', 'fixpoint',
-                'origin', 'rotation', 'rotation_origin', 
+                'origin', 'rotation', 'rotation_origin',
                 'radius', 'lengths','distance', 'spacing')
         for i in required:
             if not check_opt(grid,i):


### PR DESCRIPTION
Please configure your editors to not add whitespace at the end of the line :-)