### PR TITLE
included information about open-shell output into documentation close…

### DIFF
--- a/doc/input.rst
+++ b/doc/input.rst
@@ -97,15 +97,11 @@ acid=on
 
 Produce files suitable for plotting with ’gnuplot’, ’ParaView’, 'JMol'
 
-* ``acid.txt``: contains information about a grid point and the ACID function value in atomic units at that point. x, y, z, f_acid(x,y,z), x,y,z are given in bohr
-* ``acid.cube``: contains information about ACID function as Gaussian cube file
 * ``acid.vti``: contains information about ACID function as VTK file compatible with ParaView
 * ``jvec.txt``: contains information about a grid point x,y,z and the current density vector in that point jx, jy, jz (x,y,z, f_current(x,y,z), the point is given in bohr (it used to be in Ångstrøm) 
 * ``jvec.vti``: contains information about the current density vector function as VTK file compatible with ParaView
 * ``jmod.txt``: contains a grid point and the modulus of the current density vector function, x,y,z, f_mod(x,y,z)
 * ``jmod.vti``: contains the signed modulus of the current density vector function and can be visualized via two isosurfaces in ParaView
-* ``jmod.cube``: contains the modulus of the current density vector function as Gaussian cube file
-* ``jmod_quasi.cube``: contains the negative part of the signed modulus as Gaussian cube file
 
 Integration
 -----------

--- a/doc/output.rst
+++ b/doc/output.rst
@@ -3,18 +3,36 @@
 Description of generated files
 ==============================
 
+Note "file.txt" means text file format and "file.vti" stands for VTK file format, which is compatible with ParaView. The text files start with a given grid point (x,y,z) followed by either information about the modulus of the current density f(x,y,z) or the components of the current density vector Jx,Jy,Jz.  
+
 * ``MOL``: contains molecular coordinates and basis functions, needed as input file for a gimic calculation
 * ``XDENS``: contains information about the AO density and first order perturbed AO density, needed as input for a gimic calculation
 * ``gimic.inp``: gimic input file, here either the cubic grid or a grid across a bond is specified, needed as input information for a gimic calculation
 * ``gimic.out``: gimic output file, contains information about the integrated current strength susceptibility
 * ``grid.xyz``: contains molecular coordinates in Ångstrøm and cube points (8) or integration plane corner points (4)
 * ``mol.xyz``: contains molecular coordinates in Ångstrøm
-* ``acid.txt``: contains information about a grid point and the ACID function value in atomic units at that point. x, y, z, f_acid(x,y,z), x,y,z are given in bohr
-* ``acid.cube``: contains information about ACID function as Gaussian cube file
-* ``acid.vti``: contains information about ACID function as VTK file compatible with ParaView
+
+closed-shell calculation:
+
+* ``acid.vti``: contains information about ACID function 
 * ``jvec.txt``: contains information about a grid point x,y,z and the current density vector in that point jx, jy, jz (x,y,z, f_current(x,y,z), the point is given in bohr (it used to be in Ångstrøm)
-* ``jvec.vti``: contains information about the current density vector function as VTK file compatible with ParaView
+* ``jvec.vti``: contains information about the current density vector function 
 * ``jmod.txt``: contains a grid point and the modulus of the current density vector function, x,y,z, f_mod(x,y,z)
-* ``jmod.vti``: contains the signed modulus of the current density vector function and can be visualized via two isosurfaces in ParaView
-* ``jmod.cube``: contains the modulus of the current density vector function as Gaussian cube file
-* ``jmod_quasi.cube``: contains the negative part of the signed modulus as Gaussian cube file
+* ``jmod.vti``: contains the signed modulus of the current density vector function 
+
+only for open-shell calculations:
+
+* ``jmodalpha.txt``: contains the signed modulus of the alpha current density vector function 
+* ``jmodalpha.vti``: contains the signed modulus of the alpha current density vector function 
+* ``jmodbeta.txt``: contains the signed modulus of the beta current density vector function 
+* ``jmodbeta.vti``: contains the signed modulus of the beta current density vector function 
+* ``jmodspindens.txt``: contains the signed modulus of the difference (alpha - beta) current density vector function 
+* ``jmodspindens.vti``: contains the signed modulus of the difference (alpha - beta) current density vector function 
+
+* ``jvecalpha.txt``: contains information about the alpha current density vector function 
+* ``jvecalpha.vti``: contains information about the alpha current density vector function 
+* ``jvecbeta.txt``: contains information about the beta current density vector function 
+* ``jvecbeta.vti``: contains information about the beta current density vector function 
+* ``jvecspindens.txt``: contains information about the difference (alpha - beta) current density vector function 
+* ``jvecspindens.vti``: contains information about the difference (alpha - beta) current density vector function 
+

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -76,6 +76,8 @@ to produce the ``MOL`` and ``XDENS`` files.
 ::
     $ turbo2gimic.py > MOL
 
+Note, open-shell calculations are not supported.
+
 
 Running QChem and FERMION++
 ---------------------------
@@ -93,6 +95,8 @@ qc2tm -h:
 USAGE: qc2tm -t <qchem or fermions> -qcout <output-file> -scr
              <scratch-directory> -s2c (opt.) -openshell (opt.)
 
+Note, open-shell calculations are not supported.
+
 Running LSDalton
 ---------------- 
 
@@ -103,6 +107,8 @@ Written by C. Kumar, University of Oslo, chandan.kumar@kjemi.uio.no
 ".GIMIC" needs to be added in LSDALTON.INP 
 
 Run in the same directory "python lsdalton2gimic.py"
+
+Note, open-shell calculations are not supported.
 
 Running Gausian
 --------------- 


### PR DESCRIPTION
…s #148 

1. included in documentation for which programs open-shell calculations are feasible with gimic
2. included information about output files in documentation
3. shortened the output file section 
4. removed information about cube files, since we do not generate them any more 