### PR TITLE
restore OpenMP parallelization; closes #168

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -28,6 +28,16 @@ Test the installation with::
   $ make test
 
 
+Parallelization
+---------------
+
+OpenMP parallelization is available::
+
+  $ ./setup --omp
+
+MPI parallelization is in the works.
+
+
 Installation on Stallo supercomputer
 ------------------------------------
 


### PR DESCRIPTION
The important change is `OMP PARALLEL DEFAULT(NONE)` which is very important to do.