### PR TITLE
corrected typo in usage.rst

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -110,8 +110,8 @@ Run in the same directory "python lsdalton2gimic.py"
 
 Note, open-shell calculations are not supported.
 
-Running Gausian
---------------- 
+Running Gaussian
+---------------- 
 
 The scripts/input needed can be found in ``/tools/g092gimic``. 
 


### PR DESCRIPTION
The header "running gaussian" had a typo. We had Gausian instead of Gaussian there. 