### PR TITLE
removed div_j and edens from interface

### DIFF
--- a/src/libgimic/GimicInterface.cpp
+++ b/src/libgimic/GimicInterface.cpp
@@ -36,15 +36,7 @@ void GimicInterface::calc_jvector(const double r[3], double jv[3]) {
     gimic_calc_jvector(r, jv);
 }
 
-void GimicInterface::calc_divj(const double r[3], double *dj) {
-    gimic_calc_divj(r, dj);
-}
-
 void GimicInterface::calc_modj(const double r[3], double *mj) {
     gimic_calc_modj(r, mj);
-}
-
-void GimicInterface::calc_edens(const double r[3], double *mj) {
-    gimic_calc_edens(r, mj);
 }
 

--- a/src/libgimic/GimicInterface.h
+++ b/src/libgimic/GimicInterface.h
@@ -11,8 +11,6 @@ class GimicInterface {
         void set_screening(double thrs);
         void calc_jtensor(const double r[3], double jt[9]);
         void calc_jvector(const double r[3], double jv[3]);
-        void calc_divj(const double r[3], double *dj);
         void calc_modj(const double r[3], double *mj);
-        void calc_edens(const double r[3], double *dj);
 };
 #endif

--- a/src/libgimic/gimic.pxd
+++ b/src/libgimic/gimic.pxd
@@ -7,6 +7,4 @@ cdef extern from "GimicInterface.h":
         void set_screening(double thrs)
         void calc_jtensor(double *r, double *jt)
         void calc_jvector(double *r, double *jv)
-        void calc_divj(double *r, double *dj)
-        void calc_edens(double *r, double *ed)
 

--- a/src/libgimic/gimic.pyx
+++ b/src/libgimic/gimic.pyx
@@ -31,22 +31,6 @@ cdef class Gimic(GimicConnector):
             vec.append(cv[i])
         return vec
 
-    cpdef divj(self, r):
-        cdef double cr[3]
-        cdef double cd
-        for i in range(3):
-            cr[i] = r[i]
-        self.thisptr.calc_divj(cr, &cd)
-        return cd
-
-    cpdef rho(self, r):
-        cdef double cr[3]
-        cdef double cd
-        for i in range(3):
-            cr[i] = r[i]
-        self.thisptr.calc_edens(cr, &cd)
-        return cd
-
     cpdef set_property(self, prop, val):
         eval('self.set_{0}({1})'.format(prop, repr(val)))
 

--- a/src/libgimic/gimic_interface.h
+++ b/src/libgimic/gimic_interface.h
@@ -15,8 +15,6 @@ extern "C" {
     void gimic_calc_jtensor(const double *, double *);
     void gimic_calc_jvector(const double *, double *);
     void gimic_calc_modj(const double *, double *);
-    void gimic_calc_divj(const double *, double *);
-    void gimic_calc_edens(const double *, double *);
 #ifdef __cplusplus
 }
 #endif

--- a/src/pygimic/connector.pxd
+++ b/src/pygimic/connector.pxd
@@ -6,8 +6,6 @@
 cdef class GimicConnector:
     cpdef jvector(self, r)
     cpdef jtensor(self, r)
-    cpdef divj(self, r)
-    cpdef rho(self, r)
     cpdef set_property(self, prop, val)
 
 # vim:et:ts=4:

--- a/src/pygimic/connector.pyx
+++ b/src/pygimic/connector.pyx
@@ -13,12 +13,6 @@ cdef class GimicConnector:
     cpdef jtensor(self, r):
         raise NotAvailable('jtensor()')
 
-    cpdef divj(self, r):
-        raise NotAvailable('divj()')
-
-    cpdef rho(self, r):
-        raise NotAvailable('rho()')
-
     cpdef set_property(self, prop, val):
         pass
 


### PR DESCRIPTION
This is a cleanup of unused stuff in the interface files. I tried to make gimic work on a Mac and during this procedure I was doing a cleanup. Afterwards gimic compiled on my Mac and all tests except the usual Valgrind suspects ran through. 