### PR TITLE
Apptainer container support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ share/*
 cmake/bump-version
 venv/
 *.DS_Store
+
+*.sif

--- a/container/README.md
+++ b/container/README.md
@@ -1,0 +1,59 @@
+# Apptainer Container
+
+This is guide on [Apptainer](https://apptainer.org/) container use for Gimic.
+
+## Building Container
+
+Build container
+
+```bash
+cd  "gimic folder"
+apptainer build --fakeroot gimic.sif container/gimic-apptainer.def
+```
+
+**Note**, you need to be in gimic folder or the build will faill. Apptainer does not support relative paths to definition file, yet, so this is important!
+
+## Using Container
+
+Container file is an executable by on its own and
+is equivalent to `gimic` command.
+
+```bash
+gimic.sif gimic.inp > gimic.out
+```
+
+All commands can be called with `apptainer exec gimic.sif <command>` calls, e.g.
+
+```bash
+apptainer exec gimic.sif gimic gimic.inp > gimic.out
+apptainer exec gimic.sif 3D-run.sh
+```
+
+This includes all executables that are located in
+
+- `build/bin/`
+- `jobscripts/`
+- `tools/`
+
+For mode detailed ways to call Gimic from the container refer
+to [Apptainer documentation](https://apptainer.org/docs/user/main/quick_start.html).
+
+### Note Certain Jobscripts Do not Work
+
+Some jobscripts call external programs like `sbatch`.
+These wont work with the container.
+Because container by definition cannot access external programs.
+
+These scripts are all located in `jobscripts` folder
+and include `cluster` in their names like `current-profile-cluster.sh`.
+But `local` versions of the commands work.
+
+## Aliases for Gimic Commands
+
+Consider also adding aliases, to make calling Gimic from the container easier, e.g.
+
+```bash
+alias gimic="path_to/gimic.sif"
+alias 3D-run.sh="apptainer exec path_to/gimic.sif 3D-run.sh"
+# etc.
+```

--- a/container/gimic-apptainer.def
+++ b/container/gimic-apptainer.def
@@ -1,0 +1,55 @@
+Bootstrap: docker
+From: ubuntu:22.04
+
+%labels
+    Author Teemu Järvinen
+    Version latest
+
+%files
+    # Only call build from gimic directory or this will fail!
+    . /opt/gimic
+
+%post
+    DEBIAN_FRONTEND=noninteractive
+    apt-get -y update
+    apt-get -y install \
+        python3 \
+        python3-dev \
+        python3-pip \
+        cython3 \
+        python3-numpy \
+        python3-pyparsing \
+        python3-yaml
+    pip install runtest
+    apt-get -y install \
+        cmake \
+        build-essential \
+        gfortran
+
+
+    # Build
+    cd /opt/gimic
+    python3 setup --omp ; \
+    cmake --build build ; \
+    cmake --install build
+
+    # Initialize jobscripts
+    cd jobscripts
+    ./setup.sh
+    cd /
+
+# These are tests. But they are broken
+#%test
+    #cd /opt/gimic
+    #cmake --build build --target test
+
+
+%environment
+    export PATH="$PATH:/opt/gimic/build/bin"
+    export PATH="$PATH:/opt/gimic/jobscripts"
+    export PATH="$PATH:/opt/gimic/tools"
+    export GIMIC_HOME="/opt/gimic/jobscripts"
+
+
+%runscript
+    gimic

--- a/container/gimic-apptainer.def
+++ b/container/gimic-apptainer.def
@@ -25,6 +25,9 @@ From: ubuntu:22.04
         cmake \
         build-essential \
         gfortran
+    
+    # Needed for visualizations
+    apt-get install -y gnuplot
 
 
     # Build
@@ -48,8 +51,27 @@ From: ubuntu:22.04
     export PATH="$PATH:/opt/gimic/build/bin"
     export PATH="$PATH:/opt/gimic/jobscripts"
     export PATH="$PATH:/opt/gimic/tools"
-    export GIMIC_HOME="/opt/gimic/jobscripts"
+    export GIMIC_HOME="/opt/gimic/"
 
 
 %runscript
     gimic
+
+
+%help
+    This is Gimic container.
+
+    Calling container directly is equal to calling "gimic".
+
+    Other Gimic commands can be called with
+    "apptainer exec path_to_container.sif <command>"
+
+    E.g.
+
+    "apptainer exec gimic_container.sif gimic gimic.inp > gimic.out"
+    "apptainer exec gimic_container.sif 3D-run.sh"
+
+    Note that commands that call slurm do not work!
+    These include jobscripts that "cluster" in their names.
+    The "local" versions should work. 
+    

--- a/src/london/density.txt
+++ b/src/london/density.txt
@@ -1,1 +1,0 @@
-../../test/ldensity.dat


### PR DESCRIPTION
This will add definition file to build [Apptainer](https://apptainer.org/) container, and a README.md file to give instructions on building and using the container.

The main point with this is to have easy access to Gimic. Basicly you only need to install Apptainer, after which you can build the container and have access to Gimic without the need to install any dependencies. Also, moving Gimic binary (container) to other computers becames trivial with the container framework.
 The choise of Apptainer (former Singularity) was taken because it is developed with HPC in mind and many supercomputers (like the ones in Finland) use it.

The problem with the container is that some of the scripts in `jobscripts` folder call external programs. These wont work with the container. Because by definition container does not depend on external programs. This mainly affects scripts with "cluster" in their name, as they call Slurm. The versions with "local" in their names should work.

For visualization scripts, I added gnuplot into the container. This does however increase the size of the container by an extra 100MB to about 370MB total.

@mariavd promised to edit the scripts, so that they work with the container.
 In my opinnion, the way to go, is to remove all Slurm commands from the scripts and have the scripts output Slurm batch file, which the user can submit outside the container. That being said there is a lot of room to improve the scripts in general...

But other than that, the Gimic container should be fully working.